### PR TITLE
Fix typographical error(s)

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ Superglobal request variables (`$_GET`, `$_POST`, `$_COOKIE`,
 `$_SERVER`, etc.) are not ready until after `Prefork::fork()`. You
 MUST NOT access them earlier.
 
-Certian resource types are reused by each of one worker's interns in
+Certain resource types are reused by each of one worker's interns in
 turn. By way of example, MySQL and Memcache connections are typically
 reused, but with no concurrency due to the limit of one intern per
 worker. Thus if you use any persistent resources like these, you


### PR DESCRIPTION
@Automattic, I've corrected a typographical error in the documentation of the [prefork](https://github.com/Automattic/prefork) project. Specifically, I've changed certian to certain. You should be able to merge this pull request automatically. However, if this was intentional or if you enjoy living in linguistic squalor, please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.
